### PR TITLE
Update service-settings.js

### DIFF
--- a/view/adminhtml/web/js/service-settings.js
+++ b/view/adminhtml/web/js/service-settings.js
@@ -34,7 +34,7 @@ require([
         } else {
             depend = depends[key];
         }
-        elements.each(function(id, index) {
+        $(elements).each(function(id, index) {
             var el = getField(id).parents('.field');
             if (depend[index] == 1) {
                 el.show();


### PR DESCRIPTION
When attempting to add a new e-mail service I am presented with the following error:
`TypeError: elements.each is not a function service-settings.js:37:9.`

It would appear that the root cause was an attempt to call a method .each() which doesn't exist on vanilla javascript array objects, whereas this is a valid jQuery method.

The above code change addresses this problem.